### PR TITLE
Use utils.get_script_dir() instead of os.get_cwd()

### DIFF
--- a/scripts/Modules/TTK_Lib.py
+++ b/scripts/Modules/TTK_Lib.py
@@ -260,7 +260,7 @@ def writeToCSV(inputs: FrameSequence, playerType: PlayerType) -> None:
     # Get csv file path
     playerStr = "Player" if playerType == PlayerType.PLAYER else "Ghost"
     relativePath = config.textFilePath(playerStr)
-    absolutePath = os.path.join(os.getcwd(), "User/Load/Scripts/", relativePath)
+    absolutePath = os.path.join(utils.get_script_dir(), relativePath)
     
     # Write to csv, error if cannot write
     if inputs.writeToFile(absolutePath):
@@ -273,7 +273,7 @@ def writeToCSV(inputs: FrameSequence, playerType: PlayerType) -> None:
 def writeToBackupCSV(inputs: FrameSequence, backupNumber: int) -> None:
     relativePath = config.textFilePath("Backup")
     relativePath = relativePath.replace("##", "{:02d}".format(backupNumber))
-    inputs.writeToFile(os.path.join(os.getcwd(), "User/Load/Scripts/", relativePath))
+    inputs.writeToFile(os.path.join(utils.get_script_dir(), relativePath))
         
 def getMetadataAndWriteToRKG(inputs: FrameSequence, playerType: PlayerType) -> None:
     # Get metadata
@@ -295,7 +295,7 @@ def writeToRKG(fileBytes: bytearray, playerType: PlayerType) -> None:
     # Get csv file path
     playerStr = "Player" if playerType == PlayerType.PLAYER else "Ghost"
     relativePath = config.rkgFilePath[playerStr]
-    absolutePath = os.path.join(os.getcwd(), "User/Load/Scripts/", relativePath)
+    absolutePath = os.path.join(utils.get_script_dir(), relativePath)
     
     try:
         with open(absolutePath, "wb") as f:
@@ -310,7 +310,7 @@ def getInputSequenceFromCSV(playerType: PlayerType) -> FrameSequence:
     # Get csv file path
     playerStr = "Player" if playerType == PlayerType.PLAYER else "Ghost"
     relativePath = config.textFilePath(playerStr)
-    absolutePath = os.path.join(os.getcwd(), "User/Load/Scripts/", relativePath)
+    absolutePath = os.path.join(utils.get_script_dir(), relativePath)
     
     # Get the frame sequence
     return FrameSequence(absolutePath)


### PR DESCRIPTION
We can't always necessarily use `os.get_cwd()`. For example, when debugging Dolphin in Visual Studio, this call resolves to the DolphinQt directory. It's more reliable to use Dolphin to determine the Scripts dir.