### PR TITLE
Fix RKGs containing no trick data

### DIFF
--- a/scripts/Modules/TTK_Lib.py
+++ b/scripts/Modules/TTK_Lib.py
@@ -152,7 +152,7 @@ class RKGTuple:
 
 def encodeTuple(input: int, frames: int, inputType: ControllerInputType) -> RKGTuple:
     if (inputType == ControllerInputType.TRICK):
-        return RKGTuple(input + frames >> 8, frames % 0x100)
+        return RKGTuple(input + (frames >> 8), frames % 0x100)
     else:
         return RKGTuple(input, frames)
 


### PR DESCRIPTION
Python [operator precedence](https://docs.python.org/3/reference/expressions.html#operator-precedence) states that addition occurs before bitwise operators.